### PR TITLE
Remove unused pecl manual configurations

### DIFF
--- a/sgrv2/pecl.php.net-ssl.conf
+++ b/sgrv2/pecl.php.net-ssl.conf
@@ -34,7 +34,6 @@ NameVirtualHost 69.195.199.133:443
 
     Alias /package /usr/local/www/peclweb/public_html/package-info.php
 
-    RedirectPermanent /download-docs.php          http://pecl2.php.net/manual/
     RedirectPermanent /rss.php          http://pecl2.php.net/feeds/latest.rss
 
     # Temp redirect until aliases are in place in the pkg manager, don't remove
@@ -71,10 +70,6 @@ NameVirtualHost 69.195.199.133:443
     </Location>
 
     ErrorDocument 404 /error/404.php
-
-    <Location /manual>
-        ErrorDocument 404 /error/404-manual.php
-    </Location>
 
     <Location /server-status>
         SetHandler server-status

--- a/sgrv2/pecl.php.net.conf
+++ b/sgrv2/pecl.php.net.conf
@@ -28,7 +28,6 @@
     Alias /package /home/www/pecl.php.net/public_html/package-info.php
     Alias /user    /home/www/pecl.php.net/public_html/account-info.php
 
-    RedirectPermanent /download-docs.php          http://pecl2.php.net/manual/
     RedirectPermanent /rss.php          http://pecl2.php.net/feeds/latest.rss
 
     # Temp redirect until aliases are in place in the pkg manager, don't remove
@@ -41,7 +40,6 @@
 
 
     RewriteEngine On
-    #RewriteRule   /download-docs.php    /manual/index.php [R=301]
     #RewriteRule   /rss.php             /feeds/latest.rss [R=301]
 
     #
@@ -64,10 +62,6 @@
     </Location>
 
     ErrorDocument 404 /error/404.php
-
-    <Location /manual>
-        ErrorDocument 404 /error/404-manual.php
-    </Location>
 
     <Location /server-status>
         SetHandler server-status
@@ -121,7 +115,6 @@
 
     Alias /soap_interop /home/ssb/cvs/pear/SOAP/interop
 
-    RedirectPermanent /download-docs.php          http://pecl2.php.net/manual/
     RedirectPermanent /rss.php          http://pecl2.php.net/feeds/latest.rss
 
     # Temp redirect until aliases are in place in the pkg manager, don't remove
@@ -157,10 +150,6 @@
     </Location>
 
     ErrorDocument 404 /error/404.php
-
-    <Location /manual>
-        ErrorDocument 404 /error/404-manual.php
-    </Location>
 
     <Location /server-status>
         SetHandler server-status


### PR DESCRIPTION
Hello, the PECL manual paths were once part of the pecl.php.net and were removed during peclweb application refactorings. These locations were then permanently removed and synced from the application via:
https://git.php.net/?p=web/pecl.git;a=commit;h=1543bf0332f5263849d0ff1e9e8a212783e4d8c9

Done at pull request: https://github.com/php/web-pecl/pull/37

Patch to update the production Apache configuration:

```patch
- RewriteRule   /download-docs.php    /manual/index.php [R=301]

# ...

- <Location /manual>
-     ErrorDocument 404 /error/404-manual.php
- </Location>
```

Thank you.