### PR TITLE
Fix PECL website cron job location

### DIFF
--- a/update-win-pkg-cache
+++ b/update-win-pkg-cache
@@ -1,2 +1,2 @@
 #!/bin/sh
-sudo -u nobody php /usr/local/www/peclweb/cron/update-win-pkg-cache.php
+sudo -u nobody php /usr/local/www/peclweb/bin/cron/update-win-pkg-cache.php


### PR DESCRIPTION
Patch via the web/pecl repository
http://git.php.net/?p=web/pecl.git;a=commitdiff;h=229a0e0888163ffef15f4d81b48ee53339986ae2
has moved the cron job to a new bin directory. It currently doesn't seem that this cron job is running or that is needed on the server but anyway this patch fixes and updates this for the future info anyway.

A just in case info when things will be updated or so... Thanks.