### PR TITLE
Fix NTP continent for euk2

### DIFF
--- a/boxen/euk2.php.net
+++ b/boxen/euk2.php.net
@@ -1,6 +1,6 @@
 # Service configuration for euk2.php.net 
 
-export CONTINENT="eu"
+export CONTINENT="europe"
 
 HOURLY="update-systems update-docs-sources build-docs-snapshots update-phd-docs"
 DAILY="update-time "


### PR DESCRIPTION
There is no "eu.pool.ntp.org"; it should be "europe.pool.ntp.org" instead.