### PR TITLE
Transfer targets of prototype subdomains to myself

### DIFF
--- a/php.net.zone
+++ b/php.net.zone
@@ -243,8 +243,8 @@ mx2.tests.php.net.	IN MX 10 10.0.0.10.
 mx2.tests.php.net.	IN MX 20 10.0.0.20.
 
 ; streamservice (prototype website for new design)
-prototype		IN CNAME proto.php.streamservice.nl.
-ns6.is.not.my.friend	IN CNAME proto.php.streamservice.nl.
+prototype		IN CNAME php-web.markrandall.uk.
+prototype-meta		IN CNAME php-meta.markrandall.uk.
 
 ; php.net.		IN CAA	0 issue "gandi.net"
 ; php.net.		IN CAA	0 iodef "mailto:systems@php.net"

--- a/php.net.zone
+++ b/php.net.zone
@@ -242,7 +242,7 @@ mx1.tests.php.net.	IN MX 10 127.0.0.1.
 mx2.tests.php.net.	IN MX 10 10.0.0.10.
 mx2.tests.php.net.	IN MX 20 10.0.0.20.
 
-; streamservice (prototype website for new design)
+; prototype website for new design (contact: marandall@php.net)
 prototype		IN CNAME php-web.markrandall.uk.
 prototype-meta		IN CNAME php-meta.markrandall.uk.
 


### PR DESCRIPTION
At the start of this year I started putting a bit of time into what I hope could be a successor to the php.net website (https://news-web.php.net/php.webmaster/28454, https://news-web.php.net/php.webmaster/28481), and I would like to place it under a php.net subdomain. 

Salathe has directed me to the prototype.php.net domain which appears to be currently sitting unused. 

I therefore request that the DNS be adjusted to transfer control of two prototype subdomains to myself, where I will host a prototype version until such a time that the site can be put up for approval and hopefully, eventually, full deployment, at which point it would be transferred onto existing infrastructure.  