### PR TITLE
Use OhDear as status-page for php.net

### DIFF
--- a/php.net.zone
+++ b/php.net.zone
@@ -90,7 +90,7 @@ rsync			IN CNAME sc2.php.net.
 testfest		IN CNAME dp1a.php.net.
 
 ; Network Health Status Page
-status			IN CNAME osu1php.osuosl.org.
+status			IN CNAME status.ssl.ohdear.app.
 
 pear			IN CNAME euk3.php.net.
 pear2			IN CNAME euk3.php.net.


### PR DESCRIPTION
Currently calling status.php.net will redirect the caller to php.net
which does not make too much sense. As OhDear has offered to sponsor
status-monitoring for php.net this change provides a DNS-record for
displaying a decent status page that we do not need to take care of
apart from configuring.