### PR TITLE
Fix missing emails for brazilian translation

### DIFF
--- a/build-docs-snapshots
+++ b/build-docs-snapshots
@@ -167,7 +167,9 @@ broken_lang ()
 		pt_BR)
 			toaddr="doc-pt-br@lists.php.net"
 		;;
-
+		pt_br)
+			toaddr="doc-pt-br@lists.php.net"
+		;;
 		*)
 			toaddr="doc-$1@lists.php.net"
 		;;

--- a/build-docs-snapshots
+++ b/build-docs-snapshots
@@ -164,9 +164,6 @@ broken_lang ()
 		;;
 
 		# Slightly inconsistent mailinglist addr :)
-		pt_BR)
-			toaddr="doc-pt-br@lists.php.net"
-		;;
 		pt_br)
 			toaddr="doc-pt-br@lists.php.net"
 		;;


### PR DESCRIPTION
Due to the now lowercase name of the translation folder the emails are currently being sent to the mailinglist `doc-pt@lists.php.net` instead of `doc-pt-br@lists.php.net`. This commit fixes that