### PR TITLE
Fix issue with pt_BR not being updated

### DIFF
--- a/build-docs-rsync
+++ b/build-docs-rsync
@@ -32,8 +32,9 @@ cd $BASE_DIR
 
 for i in $langs; do
   # Update the translation files
-  assertUpToDateRepo $i $i
-  /bin/bash /local/systems/build-docs-lang-rsync $i >>/tmp/log-$i 2>&1;
+  folder=`echo "$i" | tr '[:upper:]' '[:lower:]'`
+  assertUpToDateRepo $folder $i
+  /bin/bash /local/systems/build-docs-lang-rsync $folder >>/tmp/log-$i 2>&1;
 done
 
 # Build manual lookup db

--- a/update-docs-sources
+++ b/update-docs-sources
@@ -13,7 +13,8 @@ done
 langs=`/usr/bin/php -r 'include "/local/src/phpweb/include/languages.inc"; echo implode( " ", array_keys( $ACTIVE_ONLINE_LANGUAGES ) );'`;
 langs="base $langs"
 for i in $langs; do
-  cd /local/src/phpdoc-git/$i
+  lang=`echo "$i" | tr '[:upper:]' '[:lower:]'`
+  cd /local/src/phpdoc-git/$lang
   git fetch origin && git reset --hard origin/master
 done
 


### PR DESCRIPTION
Due to the lower-case name of the repo-folder and the mixed-case language name the brazilian translation was not updated. 

This commit fixes this