### PR TITLE
Dkim and tidy up

### DIFF
--- a/php.net.zone
+++ b/php.net.zone
@@ -95,9 +95,6 @@ pear			IN CNAME euk3.php.net.
 pear2			IN CNAME euk3.php.net.
 pyrus			IN CNAME euk3.php.net.
 
-www.pecl		IN CNAME pair12.php.net.
-; old pecl box
-; pecl			IN CNAME pair12.php.net.
 pecl			IN A 104.236.228.160
 
 ; Misc. PEAR sites
@@ -105,7 +102,9 @@ blog.pear 		IN CNAME euk3.php.net.
 download.pear       	IN CNAME euk3.php.net.
 de.pear.php.net	IN CNAME euk3.php.net.
 
+; Misc Other sites
 wiki.php.net.		IN A 45.55.181.207
+monitoring		IN CNAME bk2.php.net.
 
 ; Ecelerity MX running on OSU1
 ecelerity		IN CNAME osu1php.osuosl.org.
@@ -115,20 +114,28 @@ php.net.		IN TXT "_globalsign-domain-verification=YKIbqgUIt0x2vDkmdYS8TzqfqP6jyV
 php.net.		IN TXT "google-site-verification=R0anXzbL507wmRx5iv1S-5jN55RYVo2UYIqFP2L_k1g"
 php.net.		IN TXT "google-site-verification=kEZx29YwmdFCUifeR9miIOp-x_gvEpo_T_o9UzbilLA"
 
-monitoring		IN CNAME bk2.php.net.
+; DKIM key mail for php.net
+mx._domainkey.php.net.	IN TXT "t=y; g=; k=rsa; p=MHwwDQYJKoZIhvcNAQEBBQADawAwaAJhANg8QYJB/6O2nGfNk1td5uRl1MMqETEAv/Jyv3wGPpoW7drSEVa7RsuZBgut/koWyJIpe0TWQRSSk+N6E0lNxkMwZVBSDU+HOpeO4+khXWtsq9Mv9BsAbPbf8VrgP5VsLQIDAQAB"
+mail._domainkey.php.net.	IN TXT ( "v=DKIM1; h=sha256; k=rsa; s=email; "
+	"p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoTM+yKcObXSpuy9sAQP3pXM0kGg2Kbt6Uqf57ZGY7iNBrN/FB3w+xuYm8Ofk947N/dixNxCzhJ0yJ675m2fQap+EmBWke02OIl3jnqNccVuSpYTbIDQlsDDfQWrXKRgL6tA6l2WidxsosB5lf6IrIYXBWxTYJAB+aWuiJyFe+tfFZWnlPId7mFnda5PEpl3itg1xIbqLJgIhxZ"
+	"nZWwKg3/SJR1067tT4VuMw7fLJCMy1exDK2HMjWTUVMsJDJh/cv28M86GwkKDZjiHpBKXXVLeJeti9Iua/seYFt0Id7/A3wtu7IPHHTFLMqb4b1j5djWpNwwtcRTVPFN24CI9wYwIDAQAB" )
 
 
-; lists operated from pair1
-lists.php.net.		IN A 104.236.36.140
+; lists operated from qa
+lists.php.net.		IN CNAME qa.php.net
 lists.php.net.		IN MX 0 php-smtp4-ip4.php.net.
-; any issues with relaying through php-smtp4? reactivate below line + deactivate above line
-;lists.php.net.		IN MX 10 pair1.php.net.
-lists.php.net.		IN TXT "v=spf1 a mx a:osu1php.osuosl.org. ip4:76.75.200.58"
-_dmarc.lists.php.net.      IN TXT "v=DMARC1; p=none"
+lists.php.net.		IN TXT "v=spf1 a mx a:osu1php.osuosl.org. ip4:45.112.84.5 ip6:2a02:cb43:8000::1102" ; ip4/6 of qa.php.net
+
+; DMARC and DKIM key mail for lists.php.net
+_dmarc.lists.php.net.		IN TXT "v=DMARC1; p=none"
+mail._domainkey.lists.php.net.	IN TXT ( "v=DKIM1; h=sha256; k=rsa; s=email; "
+	"p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtwBTcZalhSYtt2cyx+XD9CnvcelfnkEthOe1wFFKg+6YAwoVazJysjYszOtAuNhBN3Uo2cpEUqDX0hx36hp0f92Xhcb8Mg4hkPEgDBWUnMjd3re23x85yD4VIQWt7lZGMYiVdfDYVPL/utYzVJ3HkMnhJW9CvTjaurKfE/dyeSeu1/BSSbe55y5k4axVdOYyJ/QEbqK5+C3Hmb"
+	"Ku4DtkNpOijhgL/9vRXPAznasXB1IEDvQ/sySBxtJ51HCLpteTBabQ4T5A8pRsphOjJYSoSQ3OwD9k2H1m2Whcu0GTC0J1PkPiOZENprOKdqMP3ej4b6eZB1lkxiYpRccWd1m9TQIDAQAB" )
+
 
 ; Let's Encrypt ACME challenge
-
 _acme-challenge.php.net.	IN CNAME _acme--challenge-php-net.ax4z.com.
+
 
 ;------------ Physical boxen
 
@@ -220,18 +227,6 @@ main		       IN A 142.93.197.176
 		       IN AAAA 2604:a880:400:d0::1c74:1001
 newpear              IN A 157.230.57.99
                      IN AAAA 2604:a880:400:d1::a64:c001
-
-; DomainKeys
-mx._domainkey.php.net.	IN TXT "t=y; g=; k=rsa; p=MHwwDQYJKoZIhvcNAQEBBQADawAwaAJhANg8QYJB/6O2nGfNk1td5uRl1MMqETEAv/Jyv3wGPpoW7drSEVa7RsuZBgut/koWyJIpe0TWQRSSk+N6E0lNxkMwZVBSDU+HOpeO4+khXWtsq9Mv9BsAbPbf8VrgP5VsLQIDAQAB"
-; DKIM key mail for php.net
-mail._domainkey.php.net.	IN TXT ( "v=DKIM1; h=sha256; k=rsa; s=email; "
-	"p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAoTM+yKcObXSpuy9sAQP3pXM0kGg2Kbt6Uqf57ZGY7iNBrN/FB3w+xuYm8Ofk947N/dixNxCzhJ0yJ675m2fQap+EmBWke02OIl3jnqNccVuSpYTbIDQlsDDfQWrXKRgL6tA6l2WidxsosB5lf6IrIYXBWxTYJAB+aWuiJyFe+tfFZWnlPId7mFnda5PEpl3itg1xIbqLJgIhxZ"
-	"nZWwKg3/SJR1067tT4VuMw7fLJCMy1exDK2HMjWTUVMsJDJh/cv28M86GwkKDZjiHpBKXXVLeJeti9Iua/seYFt0Id7/A3wtu7IPHHTFLMqb4b1j5djWpNwwtcRTVPFN24CI9wYwIDAQAB" ) ;
-
-; DKIM key mail for lists.php.net
-mail._domainkey.lists.php.net. IN      TXT     ( "v=DKIM1; h=sha256; k=rsa; s=email; "
-          "p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtwBTcZalhSYtt2cyx+XD9CnvcelfnkEthOe1wFFKg+6YAwoVazJysjYszOtAuNhBN3Uo2cpEUqDX0hx36hp0f92Xhcb8Mg4hkPEgDBWUnMjd3re23x85yD4VIQWt7lZGMYiVdfDYVPL/utYzVJ3HkMnhJW9CvTjaurKfE/dyeSeu1/BSSbe55y5k4axVdOYyJ/QEbqK5+C3Hmb"
-          "Ku4DtkNpOijhgL/9vRXPAznasXB1IEDvQ/sySBxtJ51HCLpteTBabQ4T5A8pRsphOjJYSoSQ3OwD9k2H1m2Whcu0GTC0J1PkPiOZENprOKdqMP3ej4b6eZB1lkxiYpRccWd1m9TQIDAQAB" )  ;
 
 ; Misc stuff
 localhost		IN A 127.0.0.1

--- a/php.net.zone
+++ b/php.net.zone
@@ -124,6 +124,7 @@ lists.php.net.		IN MX 0 php-smtp4-ip4.php.net.
 ; any issues with relaying through php-smtp4? reactivate below line + deactivate above line
 ;lists.php.net.		IN MX 10 pair1.php.net.
 lists.php.net.		IN TXT "v=spf1 a mx a:osu1php.osuosl.org. ip4:76.75.200.58"
+_dmarc.lists.php.net.      IN TXT "v=DMARC1; p=none"
 
 ; Let's Encrypt ACME challenge
 


### PR DESCRIPTION
From @heiglandreas in #20:

This will enable DMARC for the list-emails. This should make delivering emails to gmail easier.

This is just an empty DMARC rule that does nothing at all but makes sure that gmail knows that we have DMARC. We could add some reporting to some email-addresses but we'd somehow need to monitor and evaluate that and I'm not sure where and how. So far I have found some systems that can aggregate those reports but those are pricey. Some OSS solutions require a lot of setup and I'd rather test that first and then see whether it makes sense in the first place. And so long we can use the "empty" DMARC rule

----

Supersedes #20 /cc @heiglandreas @TimWolla