### PR TITLE
Remove gettext special case from gen-phpweb-sqlite-db.php

### DIFF
--- a/gen-phpweb-sqlite-db.php
+++ b/gen-phpweb-sqlite-db.php
@@ -44,10 +44,6 @@ $sql = "CREATE TABLE fs (
 try {
 	$res = $dbh->query( $sql );
 	$res = $dbh->query( 'CREATE INDEX map ON fs (lang,keyword)' );
-
-	// Insert the underscore function, _(), which is an alias to gettext(), before anything else (Bug #63490)
-	$dbh->exec("INSERT INTO fs(lang,prefix,keyword,name,prio) VALUES('en','function.','_','/manual/en/function.gettext.php',1)");
-
 } catch ( PDOException $e ) {
 	echo 'Error: Cannot create db table. Here is the error message: ' . $e->getMessage() . PHP_EOL;
 	exit;


### PR DESCRIPTION
After https://github.com/php/doc-en/pull/3556 being merged, this special case for gettext will not be needed, as an entry for `_()` will be correctly added to the database.

The only difference is that an extra entry will added for it with the keyword field being empty, as `metaphone('_')` returns an empty string, but there are some other entries with empty string for the keyword field.

https://github.com/php/systems/blob/8f737fa154fdcc70215a8bd746c6ee4a335734a4/gen-phpweb-sqlite-db.php#L163-L164

- Related to https://github.com/php/doc-en/pull/3556