### PR TITLE
Retire (disable) a bunch of inactive mailing lists / newsgroups

### DIFF
--- a/qa/colobus/config
+++ b/qa/colobus/config
@@ -1,4 +1,4 @@
-#
+##
 # Edit this file in https://github.com/php/systems repo!
 #
 
@@ -78,13 +78,6 @@ group php.dev {
   desc => Developing the PHP language and runtime (list deprecated, use internals@lists.php.net)
 }
 
-#group php.version5.dev {
-# path => /var/spool/mlmmj/php5-dev
-# mail => php5-dev@lists.php.net
-# desc => developing the php5 language and runtime
-# first => 335
-#}
-
 group php.doc {
   num => 7
   path => /var/spool/mlmmj/phpdoc
@@ -110,7 +103,6 @@ group php.doc.cvs {
 group php.doc.chm {
   num => 8
   path => /var/spool/mlmmj/php-doc-chm
-  mail => php-doc-chm@lists.php.net
   desc => Developing the Windows Help (CHM) format of the documentation
 }
 
@@ -124,25 +116,21 @@ group php.doc.web {
 group php.doc.ar {
   num => 10
   path => /var/spool/mlmmj/doc-ar
-  mail => doc-ar@lists.php.net
   desc => Creating the Arabic documentation translation
 }
 group php.doc.bg {
   num => 11
   path => /var/spool/mlmmj/doc-bg
-  mail => doc-bg@lists.php.net
   desc => Creating the Bulgarian documentation translation
 }
 group php.doc.cs {
   num => 12
   path => /var/spool/mlmmj/doc-cs
-  mail => doc-cs@lists.php.net
   desc => Creating the Czech documentation translation
 }
 group php.doc.da {
   num => 13
   path => /var/spool/mlmmj/doc-da
-  mail => doc-da@lists.php.net
   desc => Creating the Danish documentation translation
 }
 group php.doc.de {
@@ -157,22 +145,19 @@ group php.doc.es {
   mail => doc-es@lists.php.net
   desc => Creating the Spanish documentation translation
 }
-group php.doc.el{
+group php.doc.el {
   num => 16
   path => /var/spool/mlmmj/doc-el
-  mail => doc-el@lists.php.net
   desc => Creating the Greek documentation translation
 }
 group php.doc.fa {
   num => 17
   path => /var/spool/mlmmj/doc-fa
-  mail => doc-fa@lists.php.net
   desc => Creating the Farsi documentation translation
 }
 group php.doc.fi {
   num => 18
   path => /var/spool/mlmmj/doc-fi
-  mail => doc-fi@lists.php.net
   desc => Creating the Finnish documentation translation
 }
 group php.doc.fr {
@@ -184,25 +169,21 @@ group php.doc.fr {
 group php.doc.he {
   num => 20
   path => /var/spool/mlmmj/doc-he
-  mail => doc-he@lists.php.net
   desc => Creating the Hebrew documentation translation
 }
 group php.doc.hk {
   num => 21
   path => /var/spool/mlmmj/doc-hk
-  mail => doc-hk@lists.php.net
   desc => Creating the Chinese (HK) documentation translation
 }
 group php.doc.hu {
   num => 22
   path => /var/spool/mlmmj/doc-hu
-  mail => doc-hu@lists.php.net
   desc => Creating the Hungarian documentation translation
 }
 group php.doc.id {
   num => 23
   path => /var/spool/mlmmj/doc-id
-  mail => doc-id@lists.php.net
   desc => Creating the Indonesian documentation translation
 }
 group php.doc.it {
@@ -220,37 +201,31 @@ group php.doc.ja {
 group php.doc.kr {
   num => 26
   path => /var/spool/mlmmj/doc-kr
-  mail => doc-kr@lists.php.net
   desc => Creating the Korean documentation translation
 }
 group php.doc.lt {
   num => 27
   path => /var/spool/mlmmj/doc-lt
-  mail => doc-lt@lists.php.net
-  desc => Creating the LT documentation translation
+  desc => Creating the Lithuanian documentation translation
 }
 group php.doc.nl {
   num => 28
   path => /var/spool/mlmmj/doc-nl
-  mail => doc-nl@lists.php.net
-  desc => creating the dutch documentation translation
+  desc => Creating the Dutch documentation translation
 }
 group php.doc.no {
   num => 93
   path => /var/spool/mlmmj/doc-no
-  mail => doc-no@lists.php.net
-  desc => creating the Norwegian documentation translation
+  desc => Creating the Norwegian documentation translation
 }
 group php.doc.pl {
   num => 29
   path => /var/spool/mlmmj/doc-pl
-  mail => doc-pl@lists.php.net
   desc => Creating the Polish documentation translation
 }
 group php.doc.pt {
   num => 30
   path => /var/spool/mlmmj/doc-pt
-  mail => doc-pt@lists.php.net
   desc => Creating the Portuguese documentation translation
 }
 group php.doc.pt-br {
@@ -262,37 +237,31 @@ group php.doc.pt-br {
 group php.doc.ro {
   num => 32
   path => /var/spool/mlmmj/doc-ro
-  mail => doc-ro@lists.php.net
   desc => Creating the Romanian documentation translation
 }
 group php.doc.ru {
   num => 33
   path => /var/spool/mlmmj/doc-ru
-  mail => doc-ru@lists.php.net
   desc => Creating the Russian documentation translation
 }
 group php.doc.se {
   num => 103
   path => /var/spool/mlmmj/doc-se
-  mail => doc-se@lists.php.net
   desc => Creating the Serbian documentation translation
 }
 group php.doc.sk {
   num => 34
   path => /var/spool/mlmmj/doc-sk
-  mail => doc-sk@lists.php.net
   desc => Creating the Slovak documentation translation
 }
 group php.doc.sl {
   num => 35
   path => /var/spool/mlmmj/doc-sl
-  mail => doc-sl@lists.php.net
   desc => Creating the Slovenian documentation translation
 }
 group php.doc.sv {
   num => 36
   path => /var/spool/mlmmj/doc-sv
-  mail => doc-sv@lists.php.net
   desc => Creating the Swedish documentation translation
 }
 group php.doc.tr {
@@ -304,7 +273,6 @@ group php.doc.tr {
 group php.doc.tw {
   num => 38
   path => /var/spool/mlmmj/doc-tw
-  mail => doc-tw@lists.php.net
   desc => Creating the Taiwanese documentation translation
 }
 group php.doc.zh {
@@ -317,7 +285,6 @@ group php.doc.zh {
 group php.evangelism {
   num => 40
   path => /var/spool/mlmmj/php-evangelism
-#  mail => php-evangelism@lists.php.net
   desc => Moderated discussion list about the promotion and evangelism of PHP
   moderated
 }
@@ -325,14 +292,12 @@ group php.evangelism {
 group php.embed.cvs {
   num => 41
   path => /var/spool/mlmmj/embed-cvs
-  mail => embed-cvs@lists.php.net
   desc => CVS commits for the embedded PHP module
 }
 
 group php.embed.dev {
   num => 42
   path => /var/spool/mlmmj/embed-dev
-  mail => embed-dev@lists.php.net
   desc => Discussion for the embedded PHP module
 }
 
@@ -346,7 +311,6 @@ group php.general {
 group php.general.bg {
   num => 44
   path => /var/spool/mlmmj/general-bg
-  mail => general-bg@lists.php.net
   desc => General discussions about PHP, in Bulgarian
 }
 
@@ -366,35 +330,30 @@ group php.gtk {
 group php.gtk.cvs {
   num => 47
   path => /var/spool/mlmmj/php-gtk-cvs
-  mail => php-gtk-cvs@lists.php.net
   desc => Automated mailings from commits to the PHP-GTK CVS repository
 }
 
 group php.gtk.dev {
   num => 48
   path => /var/spool/mlmmj/php-gtk-dev
-  mail => php-gtk-dev@lists.php.net
   desc => Developing the PHP-GTK extension
 }
 
 group php.gtk.doc {
   num => 49
   path => /var/spool/mlmmj/php-gtk-doc
-  mail => php-gtk-doc@lists.php.net
   desc => Writing and translating the PHP-GTK documentation
 }
 
 group php.gtk.general {
   num => 50
   path => /var/spool/mlmmj/php-gtk-general
-  mail => php-gtk-general@lists.php.net
   desc => Using the PHP-GTK extension
 }
 
 group php.gtk.webmaster {
   num => 51
   path => /var/spool/mlmmj/php-gtk-webmaster
-  mail => php-gtk-webmaster@lists.php.net
   desc => Developing and maintaining http://gtk.php.net/
 }
 
@@ -428,7 +387,6 @@ group php.kb {
 group php.lang {
   num => 56
   path => /var/spool/mlmmj/php-lang
-  mail => php-lang@lists.php.net
   desc => Developing a specification of the PHP language
 }
 
@@ -448,7 +406,6 @@ group php.migration {
 group php.mirrors {
   num => 59
   path => /var/spool/mlmmj/php-mirrors
-  mail => php-mirrors@lists.php.net
   desc => Developing and maintaining http://www.php.net/ and mirrors
 }
 
@@ -456,6 +413,7 @@ group php.notes {
   num => 60
   path => /var/spool/mlmmj/php-notes
   desc => Automated mailings from user annotations to the manual
+  followup => php.doc
 }
 
 group php.pear {
@@ -557,7 +515,6 @@ group php.qa {
 group php.qa.reports {
   num => 75
   path => /var/spool/mlmmj/qa-reports
-  mail => qa-reports@lists.php.net
   desc => make test QA reports.
 }
 
@@ -565,27 +522,23 @@ group php.smarty.cvs {
   num => 76
   path => /var/spool/mlmmj/smarty-cvs
   desc => Automated mailings from commits to the Smarty CVS repository
-  followup => smarty.dev
 }
 
 group php.smarty.dev {
   num => 77
   path => /var/spool/mlmmj/smarty-dev
-#  mail => smarty-dev@lists.php.net
   desc => Developing the Smarty template engine
 }
 
 group php.smarty.general {
   num => 78
   path => /var/spool/mlmmj/smarty-general
-#  mail => smarty-general@lists.php.net
   desc => Using the Smarty template engine to develop websites
 }
 
 group php.soap {
   num => 79
   path => /var/spool/mlmmj/soap
-  mail => soap@lists.php.net
   desc => Developing the PHP SOAP implementation
 }
 
@@ -605,15 +558,8 @@ group php.test {
 group php.xml.dev {
   num => 82
   path => /var/spool/mlmmj/php-xml-dev
-  mail => php-xml-dev@lists.php.net
   desc => The development of the PHP XML API
 }
-
-#group php.version3 {
-#  num => 83
-#  path => /var/spool/mlmmj/php3
-#  desc => Discussion about PHP 3 (no longer active, see php.general)
-#}
 
 group php.version4 {
   num => 84
@@ -632,7 +578,6 @@ group php.zend-engine.cvs {
   num => 86
   path => /var/spool/mlmmj/zend-engine-cvs
   desc => Automated mailings from commits to the Zend Engine CVS modules
-  followup => php.internals
 }
 
 group php.doc.ca {
@@ -646,8 +591,6 @@ group php.gd.cvs {
   num => 88
   path => /var/spool/mlmmj/gd-cvs
   desc => Automated mailings from commits to the GD CVS repository
-  mail => gd-devel@lists.php.net
-  followup => gd.dev
 }
 
 group php.gd.devel {
@@ -660,15 +603,12 @@ group php.gd.devel {
 group php.gd.bugs {
   num => 90
   path => /var/spool/mlmmj/gd-bugs
-  mail => gd-bugs@lists.php.net
   desc => GD Bugs Mailinglist
 }
 
 group php.qa.primary-tester {
   num => 91
   path => /var/spool/mlmmj/primary-qa-tester
-#  mail => primary-qa-tester@lists.php.net
-  followup => php.qa
   desc => News for primary QA testers
   moderated
 }
@@ -676,7 +616,6 @@ group php.qa.primary-tester {
 group php.apc.dev {
   num => 92
   path => /var/spool/mlmmj/apc-dev
-  mail => apc-dev@lists.php.net
   desc => APC Development Mailinglist
 }
 
@@ -690,21 +629,18 @@ group php.webmaster {
 group php.on.dlr {
   num => 97
   path => /var/spool/mlmmj/php-on-dlr
-  mail => php-on-dlr@lists.php.net
   desc => Implementing PHP on the DLR
 }
 
 group php.objc {
   num => 98
   path => /var/spool/mlmmj/php-objc
-  mail => php-objc@lists.php.net
   desc => An Objective-C bridge for PHP
 }
 
 group php.pdo {
   num => 99
   path => /var/spool/mlmmj/pdo
-  mail => pdo@lists.php.net
   desc => PHP Data Objects
 }
 
@@ -730,6 +666,7 @@ group svn.migration {
 group ug.admins {
   num => 104
   path => /var/spool/mlmmj/ug-admins
+  mail => ug-admins@lists.php.net
   desc => Usergroup Coordination
 }
 

--- a/qa/sync-mlmmj-and-colobus.php
+++ b/qa/sync-mlmmj-and-colobus.php
@@ -1,0 +1,96 @@
+#!/usr/bin/env php
+<?php
+
+$config_file = $argv[1] ?? "config";
+
+[ $config, $groups ] = read_config($config_file);
+
+function read_config($config_file)
+{
+    $fh = fopen($config_file, "r")
+        or die("unable to open file '{$config_file}'\n");
+
+    $config = [];
+    $groups = [];
+    $group = null;
+
+    while ($line = fgets($fh)) {
+        rtrim($line);
+        /* skip comments */
+        if (preg_match('/^\s*#/', $line)) {
+            continue;
+        }
+
+        if (preg_match('/\}/', $line)) {
+            $group = null;
+            continue;
+        }
+
+        if (preg_match('/^(.+?)=>(.+)$/', $line, $match)) {
+            $k = trim($match[1]);
+            $v = trim($match[2]);
+
+            if (strtolower($k) == 'include') {
+            /*
+             * We don't actually handle include, we don't need it here.
+                [ $more_config, $more_groups ] = read_config($v);
+                $config += $more_config;
+                $groups += $more_groups;
+            */
+                continue;
+            }
+
+            if (isset($group)) {
+                $groups[$group][$k] = $v;
+            } else {
+                $config[$k] = $v;
+            }
+        }
+
+        if (preg_match('/group\s*(\S+)\s*\{/i', $line, $match)) {
+            $group = $match[1];
+        }
+    }
+
+    return [ $config, $groups ];
+}
+
+$should_be_active = [];
+
+foreach (array_keys($groups) as $name) {
+  $path = $groups[$name]['path'];
+  if (array_key_exists('mail', $groups[$name]) || array_key_exists('followup', $groups[$name])) {
+      $should_be_active[$path] = 1;
+  }
+}
+
+if (!count($should_be_active)) {
+    die("No active groups, aborting\n");
+}
+
+$spool = '/var/spool/mlmmj';
+
+$dh = opendir($spool)
+    or die("Can't open spool directory '{$spool}'\n");
+
+while ($file = readdir($dh)) {
+    if (str_starts_with($file, '.')) {
+        continue;
+    }
+
+    $path = $spool . "/" . $file;
+
+    if (array_key_exists($path, $should_be_active)) {
+        if (file_exists($path . "/control/access")) {
+            unlink($path . "/control/access");
+            unlink($path . "/control/closedlistsub");
+            echo "{$path} opened\n";
+        }
+    } else {
+        if (!file_exists($path . "/control/access")) {
+            touch($path . "/control/access");
+            touch($path . "/control/closedlistsub");
+            echo "{$path} closed\n";
+        }
+    }
+}


### PR DESCRIPTION
This removes the alias so emails will be rejected, and removes the mail config from colobus so they'll show up as inactive lists on that side.

Lists can be re-enabled later if desired, such as if a new translation team pops up for a language that has been marked inactive.