### PR TITLE
Fix check fails sender

### DIFF
--- a/check-fails
+++ b/check-fails
@@ -13,6 +13,6 @@ if ! test -r $FAIL_LOGFILE; then
 fi
 
 (echo $SMTP_INTRO; echo; cat $FAIL_LOGFILE) | \
-    mail -s "$SMTP_SUBJECT" -r $STMP_FROM -- $SMTP_TO
+    mail -s "$SMTP_SUBJECT" -r $SMTP_FROM -- $SMTP_TO
 
 rm -f $FAIL_LOGFILE

--- a/check-fails
+++ b/check-fails
@@ -13,6 +13,6 @@ if ! test -r $FAIL_LOGFILE; then
 fi
 
 (echo $SMTP_INTRO; echo; cat $FAIL_LOGFILE) | \
-    mail -s "$SMTP_SUBJECT" $SMTP_TO -- -f$SMTP_FROM
+    mail -s "$SMTP_SUBJECT" -r $STMP_FROM -- $SMTP_TO
 
 rm -f $FAIL_LOGFILE


### PR DESCRIPTION
This has been sending emails to `-fsystem@php.net`, not setting the envelope sender as intended.