### PR TITLE
Avoid warning message from tar by not using absolute path

### DIFF
--- a/backup-thisbox
+++ b/backup-thisbox
@@ -2,6 +2,6 @@
 # $Id$
 
 # Backup the "this-box" state; tokens, keys etc.
-cd /local/backups
-tar cf - /local/this-box | bzip2 -9 > /local/backups/thisbox-`hostname`-$date.tar.bz2
-
+cd /local
+mkdir -p backups
+tar cf - this-box | bzip2 -9 > backups/thisbox-`hostname`-$date.tar.bz2


### PR DESCRIPTION
Right now we're getting this in `php-cron-box.log` on every run:

```
tar: Removing leading `/' from member names
```

This does change the format of the backups to not include `local/` in the file path, but there's nothing automated that uses these backups.