### PR TITLE
Remove unused hosts

### DIFF
--- a/php.net.zone
+++ b/php.net.zone
@@ -173,9 +173,6 @@ php-smtp4		IN AAAA 2a02:cb43:8000::1102
 php-jump2		IN A 116.203.146.57
 php-jump2		IN AAAA 2a01:4f8:c2c:3b3f::1
 
-php-jump3		IN A 208.43.231.10
-php-jump3		IN AAAA 2a02:cb41::1001
-
 php-jump4		IN A 45.112.84.7
 php-jump4		IN AAAA 2a02:cb43:8000::1104
 
@@ -209,18 +206,12 @@ qa		       IN A 104.236.36.140
 		       IN AAAA 2604:a880:800:10::2d6:2001
 downloads-origin	IN A 104.236.32.144
 		       IN AAAA 2604:a880:800:10::2dd:1
-idle		       IN A 104.236.32.173
-		       IN AAAA 2604:a880:800:10::2dd:1001
 main-origin	       IN A 142.93.197.176
 		       IN AAAA 2604:a880:400:d0::1c74:1001
 analytics-origin	IN A 167.71.2.31
 			IN AAAA 2a03:b0c0:2:d0::1865:c001
 wiki-origin		IN A 45.55.181.207
 			IN AAAA 2604:a880:800:10::107a:4001
-
-; DigitalOcean - Unknown
-newpear              IN A 157.230.57.99
-                     IN AAAA 2604:a880:400:d1::a64:c001
 
 ; Misc stuff
 localhost		IN A 127.0.0.1


### PR DESCRIPTION
php-jump3 was already decommissioned. idle and newpear droplets may still need to be deleted.