### PR TITLE
Verify php.net ownership on Google Search Console

### DIFF
--- a/php.net.zone
+++ b/php.net.zone
@@ -161,6 +161,9 @@ mail._domainkey.lists.php.net.	IN TXT ( "v=DKIM1; h=sha256; k=rsa; s=email; "
 ; Let's Encrypt ACME challenge
 _acme-challenge.php.net.	IN CNAME _acme--challenge-php-net.ax4z.com.
 
+; Google Search Console
+m36okhbj6s7x.php.net.		IN CNAME gv-4gej6lgi72uqv5.dv.googlehosted.com.
+
 ;------------ Physical boxen
 
 ; Myracloud, contact sascha@schumann.net and noc@myracloud.com


### PR DESCRIPTION
I’d like to verify ownership for [php.net](http://php.net/) in Google Search Console under The PHP Foundation account.

This will allow:
- Get additional stats on how people get through search to the website and incorporate it into analytics https://wiki.php.net/rfc/phpnet-analytics

- Fix indexing issues, e.g. if you search “php timeline” you’ll get a 404 php.net link in the search results and some scam page on top:

![image](https://github.com/user-attachments/assets/e083eed5-7c04-49f9-9727-119f1efc840d)
https://www.php.net/results.php?q=supported-versions.PHP&p=404manual&l=en

 To verify ownership, I’d need to add CNAME record.