### PR TITLE
Add support for web-downloads API

### DIFF
--- a/downloads.php.net/apache2/downloads.php.net.conf
+++ b/downloads.php.net/apache2/downloads.php.net.conf
@@ -33,6 +33,16 @@
 	RewriteEngine On
 	RewriteRule ^/$ https://php.net/ [L]
 
+	# Handle Authorization Header
+	RewriteCond %{HTTP:Authorization} .
+	RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+
+	# Send all non ~/windows requests to index.php
+	RewriteCond %{REQUEST_URI} !^/~windows/
+	RewriteCond %{REQUEST_FILENAME} !-d
+	RewriteCond %{REQUEST_FILENAME} !-f
+	RewriteRule ^ index.php [L]
+
 	<FilesMatch ".+\.phps$">
 		SetHandler application/x-httpd-php-source
 		# Deny access to raw php sources by default


### PR DESCRIPTION
This PR adds support to call the API in web-downloads.

It adds support for sending a bearer token for authentication and it redirect all non ~windows traffic to index.php.
