### PR TITLE
Rewrite requests only for web-downloads api

### DIFF
--- a/downloads.php.net/apache2/downloads.php.net.conf
+++ b/downloads.php.net/apache2/downloads.php.net.conf
@@ -37,8 +37,8 @@
 	RewriteCond %{HTTP:Authorization} .
 	RewriteRule .* - [E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
-	# Send all non /~.* user dir requests to index.php
-	RewriteCond %{REQUEST_URI} !^/~
+	# Send all api requests to index.php
+	RewriteCond %{REQUEST_URI} ^/api
 	RewriteCond %{REQUEST_FILENAME} !-d
 	RewriteCond %{REQUEST_FILENAME} !-f
 	RewriteRule ^ index.php [L]


### PR DESCRIPTION
This PR:

- Changes the rewrite rules in downloads.php.net to rewrite to index.php only for /api